### PR TITLE
[1/2] native: Add flag for TARGET_HAS_PREBUILT_HWC

### DIFF
--- a/services/surfaceflinger/Android.mk
+++ b/services/surfaceflinger/Android.mk
@@ -172,6 +172,10 @@ ifeq ($(TARGET_USES_QCOM_BSP), true)
     LOCAL_CFLAGS += -DQTI_BSP
 endif
 
+ifeq ($(TARGET_USES_PREBUILT_HWC),true)
+    LOCAL_CFLAGS += -DPREBUILT_HWC
+endif
+
 LOCAL_MODULE := libsurfaceflinger
 
 LOCAL_CFLAGS += -Wall -Werror -Wunused -Wunreachable-code


### PR DESCRIPTION
Conditionally enable ABI compatibility for devices
that use a prebuilt hwcomposer

Change-Id: Iae0da31c03335536e5cdfb074ecd2ffd4c852e6b